### PR TITLE
use .env file for environment variables

### DIFF
--- a/packages/ui5-task-nwabap-deployer/lib/ui5-task-nwabap-deployer.js
+++ b/packages/ui5-task-nwabap-deployer/lib/ui5-task-nwabap-deployer.js
@@ -4,6 +4,10 @@ const Logger = require("./Logger");
 const glob = require("glob");
 const resourceFactory = require("@ui5/fs").resourceFactory;
 const ui5Deployercore = require("ui5-nwabap-deployer-core");
+const dotenv = require("dotenv");
+
+// Call dotenv, so that contents in the file are stored in the environment variables
+dotenv.config();
 
 /**
  * UI5 Tooling Task for deploying UI5 Sources to a SAP NetWeaver ABAP system

--- a/packages/ui5-task-nwabap-deployer/package.json
+++ b/packages/ui5-task-nwabap-deployer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui5-task-nwabap-deployer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "UI5 Tooling Task for deploying UI5 sources to a SAP NetWeaver ABAP system",
   "author": {
     "name": "Florian Pfeffer",
@@ -33,6 +33,7 @@
     "@ui5/fs": "^1.1.2",
     "@ui5/logger": "^1.0.2",
     "glob": "^7.1.6",
-    "ui5-nwabap-deployer-core": "^1.0.0"
+    "ui5-nwabap-deployer-core": "^1.0.0",
+    "dotenv": "^8.2.0"
   }
 }


### PR DESCRIPTION
Add the dotenv package, so that you can add your enviornment variables in a .env file on the calling application. This way you don't need to put sensitive data in the yaml file or you don't have the burden to enter the environment variables in command line.