### PR TITLE
Added client support in .env

### DIFF
--- a/packages/ui5-task-nwabap-deployer/README.md
+++ b/packages/ui5-task-nwabap-deployer/README.md
@@ -15,7 +15,7 @@ npm install ui5-task-nwabap-deployer --save-dev
     - pattern: optional `string` | `array` glob pattern to match files for deployment (e.g. `**/*.*` to match all files); if not set `**/*.*` is used
 - connection
     - server: `string` SAP NetWeaver ABAP application server information in form `protocol://host:port` (alternative: set environment variable `UI5_TASK_NWABAP_DEPLOYER__SERVER`)
-    - client: optional `string` Client of SAP NetWeaver ABAP application server; if not set default client of server is used
+    - client: optional `string` Client of SAP NetWeaver ABAP application server; if not set default client of server is used (alternative: set environment variable `UI5_TASK_NWABAP_DEPLOYER__CLIENT`)
     - useStrictSSL: optional `true|false` SSL mode handling. In case of self signed certificates the useStrictSSL mode option can be set to false to allow a deployment of files; default value: `true`
     - proxy: optional `string` Proxy to be used for communication to SAP NetWeaver ABAP application server (e.g. `http://myproxyhost:3128`).
 - authentication

--- a/packages/ui5-task-nwabap-deployer/lib/ui5-task-nwabap-deployer.js
+++ b/packages/ui5-task-nwabap-deployer/lib/ui5-task-nwabap-deployer.js
@@ -29,6 +29,14 @@ module.exports = async function({ workspace, dependencies, options }) {
     } else {
         options.configuration.connection = Object.assign({}, options.configuration.connection);
     }
+    
+    let sClient = process.env.UI5_TASK_NWABAP_DEPLOYER__CLIENT;
+    
+    if (options.configuration && options.configuration.connection && options.configuration.connection.client) {
+        client = options.configuration.connection.client;
+    } else {
+        options.configuration.connection = Object.assign({}, options.configuration.connection);
+    }
 
     if ((options.configuration && !options.configuration.authentication) &&
         (!process.env.UI5_TASK_NWABAP_DEPLOYER__USER || !process.env.UI5_TASK_NWABAP_DEPLOYER__PASSWORD)) {
@@ -75,7 +83,7 @@ module.exports = async function({ workspace, dependencies, options }) {
         const oDeployOptions = {
             conn: {
                 server: sServer,
-                client: options.configuration.connection.client,
+                client: sClient,
                 useStrictSSL: options.configuration.connection.useStrictSSL,
                 proxy: options.configuration.connection.proxy
             },

--- a/packages/ui5-task-nwabap-deployer/lib/ui5-task-nwabap-deployer.js
+++ b/packages/ui5-task-nwabap-deployer/lib/ui5-task-nwabap-deployer.js
@@ -33,7 +33,7 @@ module.exports = async function({ workspace, dependencies, options }) {
     let sClient = process.env.UI5_TASK_NWABAP_DEPLOYER__CLIENT;
     
     if (options.configuration && options.configuration.connection && options.configuration.connection.client) {
-        client = options.configuration.connection.client;
+        sClient = options.configuration.connection.client;
     } else {
         options.configuration.connection = Object.assign({}, options.configuration.connection);
     }


### PR DESCRIPTION
at my client we need to be able to deploy to multiple different systems and some where the default client isn't the dev client. I don't want to mess with the yaml file continuously to do the deployment based on branches