### PR TITLE
fixed creation of new transport with ABAP 7.5

### DIFF
--- a/packages/ui5-nwabap-deployer-core/lib/TransportManager.js
+++ b/packages/ui5-nwabap-deployer-core/lib/TransportManager.js
@@ -33,7 +33,8 @@ TransportManager.prototype.createTransport = function(sPackageName, sRequestText
             method: "POST",
             url: sUrl,
             headers: {
-                "accept": "*/*"
+                "accept": "*/*",
+                "content-type": "application/vnd.sap.as+xml; charset=UTF-8; dataname=com.sap.adt.CreateCorrectionRequest"
             },
             body: sPayload
         };


### PR DESCRIPTION
On ABAP 7.5, the endpoint requires /sap/bc/adt/cts/transports must be called with a valid content type, in order to return a response. In this case, the content type must be `application/vnd.sap.as+xml; charset=UTF-8; dataname=com.sap.adt.CreateCorrectionRequest`.

(see CL_CTS_ADT_RES_OBJ_RECORD->SET_RESPONSE on SAP NW Release 7.50)