### PR TITLE
Constant Typo Fix

### DIFF
--- a/packages/ui5-nwabap-deployer-core/lib/FileStoreUtil.js
+++ b/packages/ui5-nwabap-deployer-core/lib/FileStoreUtil.js
@@ -16,7 +16,7 @@ const OBJECT_TYPE = {
 const HTTPSTAT = {
     ok: 200,
     created: 201,
-    bad_rquest: 400,
+    bad_request: 400,
     not_authorized: 403,
     not_found: 404,
     not_allowed: 405,


### PR DESCRIPTION
There was a typo in the FileStoreUtil.js that prevented proper response handling.