### PR TITLE
Added the option to use TestMode for /UI5/ABAP_REPOSITORY_SRV

### DIFF
--- a/packages/ui5-nwabap-deployer-core/lib/UI5ABAPRepoClient.js
+++ b/packages/ui5-nwabap-deployer-core/lib/UI5ABAPRepoClient.js
@@ -98,6 +98,10 @@ module.exports = class UI5ABAPRepoClient {
             sUrl = sUrl + "&TransportRequest=" + this._oOptions.ui5.transportno;
         }
 
+        if (this._oOptions.conn.testMode) {
+            sUrl + "$TestMode=TRUE"
+        }
+
         const oRequestOptions = {
             method: isRepoExisting ? "PUT" : "POST",
             url: sUrl,

--- a/packages/ui5-nwabap-deployer-core/lib/UI5ABAPRepoClient.js
+++ b/packages/ui5-nwabap-deployer-core/lib/UI5ABAPRepoClient.js
@@ -99,7 +99,7 @@ module.exports = class UI5ABAPRepoClient {
         }
 
         if (this._oOptions.conn.testMode) {
-            sUrl + "$TestMode=TRUE";
+            sUrl + "&TestMode=TRUE";
         }
 
         const oRequestOptions = {

--- a/packages/ui5-nwabap-deployer-core/lib/UI5ABAPRepoClient.js
+++ b/packages/ui5-nwabap-deployer-core/lib/UI5ABAPRepoClient.js
@@ -99,7 +99,7 @@ module.exports = class UI5ABAPRepoClient {
         }
 
         if (this._oOptions.conn.testMode) {
-            sUrl + "$TestMode=TRUE"
+            sUrl + "$TestMode=TRUE";
         }
 
         const oRequestOptions = {

--- a/packages/ui5-task-nwabap-deployer/README.md
+++ b/packages/ui5-task-nwabap-deployer/README.md
@@ -22,6 +22,7 @@ npm install ui5-task-nwabap-deployer --save-dev
     - useStrictSSL: optional `true|false` SSL mode handling. In case of self signed certificates the useStrictSSL mode option can be set to false to allow a deployment of files; default value: `true`
     - proxy: optional `string` Proxy to be used for communication to SAP NetWeaver ABAP application server (e.g. `http://myproxyhost:3128`).
     - customQueryParams: option key/value query parameter values added to the call to the SAP NetWeaver ABAP application server
+    - testMode: optional boolean for running /UI5/ABAP_RESPOSITORY_SRV in TestMode (alternative: set environment variable UI5_TASK_NWABAP_DEPLOYER__TESTMODE)
 - authentication
     - user: `string`User used for logon to SAP NetWeaver ABAP application server (alternative: set environment variable `UI5_TASK_NWABAP_DEPLOYER__USER`)
     - password: `string` Password used for logon to SAP NetWeaver ABAP application server (alternative: set environment variable `UI5_TASK_NWABAP_DEPLOYER__PASSWORD`)

--- a/packages/ui5-task-nwabap-deployer/lib/ui5-task-nwabap-deployer.js
+++ b/packages/ui5-task-nwabap-deployer/lib/ui5-task-nwabap-deployer.js
@@ -20,14 +20,17 @@ module.exports = async function({ workspace, dependencies, options }) {
 
     oLogger.log("Start deploying UI5 sources.");
 
-    let bTestMode = !!process.env.UI5_TASK_NWABAP_DEPLOYER__TESTMODE;
-
     if ((options.configuration && !options.configuration.connection) && !process.env.UI5_TASK_NWABAP_DEPLOYER__SERVER) {
         return Promise.reject(new Error("Please provide a connection configuration."));
     }
 
     if (options.configuration && !options.configuration.connection) {
         options.configuration.connection = {};
+    }
+
+    let bTestMode = !!process.env.UI5_TASK_NWABAP_DEPLOYER__TESTMODE;
+    if (options.configuration && options.configuration.connection.testMode) {
+        bTestMode = options.configuration.connection.testMode;
     }
 
     let sServer = process.env.UI5_TASK_NWABAP_DEPLOYER__SERVER;

--- a/packages/ui5-task-nwabap-deployer/lib/ui5-task-nwabap-deployer.js
+++ b/packages/ui5-task-nwabap-deployer/lib/ui5-task-nwabap-deployer.js
@@ -20,6 +20,8 @@ module.exports = async function({ workspace, dependencies, options }) {
 
     oLogger.log("Start deploying UI5 sources.");
 
+    let bTestMode = !!process.env.UI5_TASK_NWABAP_DEPLOYER__TESTMODE;
+
     if ((options.configuration && !options.configuration.connection) && !process.env.UI5_TASK_NWABAP_DEPLOYER__SERVER) {
         return Promise.reject(new Error("Please provide a connection configuration."));
     }
@@ -92,7 +94,8 @@ module.exports = async function({ workspace, dependencies, options }) {
                 client: sClient,
                 useStrictSSL: options.configuration.connection.useStrictSSL,
                 proxy: options.configuration.connection.proxy,
-                customQueryParams: options.configuration.connection.customQueryParams ? options.configuration.connection.customQueryParams : {}
+                customQueryParams: options.configuration.connection.customQueryParams ? options.configuration.connection.customQueryParams : {},
+                testMode: bTestMode
             },
             auth: {
                 user: sUser,


### PR DESCRIPTION
Hi,

I wanted to be able to use the TestMode of the OData Service /UI5/ABAP_REPOSITORY_SRV , which is used since version 2 of this project.

You can set the environment variable UI5_TASK_NWABAP_DEPLOYER__TESTMODE to true if you want to use the TestMode.

I added this functionality to test the yaml config against the real system before I try to deploy the code