### PR TITLE
Set CLI exitCode to '1' if upload fails

### DIFF
--- a/packages/grunt-nwabap-ui5uploader/tasks/grunt-nwabap-ui5uploader.js
+++ b/packages/grunt-nwabap-ui5uploader/tasks/grunt-nwabap-ui5uploader.js
@@ -68,10 +68,10 @@ module.exports = function(grunt) {
         try {
             await ui5Deployercore.deployUI5toNWABAP(oDeployOptions, aFiles, oLogger);
             oLogger.log("UI5 sources successfully deployed.");
+            done();
         } catch (oError) {
             oLogger.error(oError);
+            process.exitCode = 1;
         }
-
-        done();
     });
 };


### PR DESCRIPTION
Currently if the upload fails, the exit code is not set, meaning the build pipeline will not fail. I believe this should resolve that.