### PR TITLE
fix(axios): fix axios vulnerabilities

### DIFF
--- a/packages/ui5-nwabap-deployer-core/package.json
+++ b/packages/ui5-nwabap-deployer-core/package.json
@@ -33,7 +33,7 @@
   ],
   "scripts": {},
   "dependencies": {
-    "axios": "^1.7.7",
+    "axios": "^1.8.3",
     "retry-axios": "^2.6.0",
     "xmldoc": "^1.1.0",
     "yazl": "^2.5.1"


### PR DESCRIPTION
- update `axios` to latest version, due to CVE https://github.com/advisories/GHSA-jr5f-v2jv-69x6
- follow up on #64. Because of #65, `retry-axios` has not been upgraded

I created another branch updated all depenendencies of `ui5-nwabap-deployer-core`: https://github.com/treee111/ui5-nwabap-deployer/tree/update-npm-dependencies
That one is working for me locally as well. Tested it like written [here](https://github.com/pfefferf/ui5-nwabap-deployer/pull/65#issuecomment-2377227172)